### PR TITLE
Minor Quickstart revisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.gradle
+.idea
+local.properties

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Daily Client SDK for Android Quickstart
+
+This is a quickstart application for Daily's [Client SDK for Android](https://docs.daily.co/reference/android).

--- a/app/src/main/java/com/example/dailyandroidquickstart_kotlin/MainActivity.kt
+++ b/app/src/main/java/com/example/dailyandroidquickstart_kotlin/MainActivity.kt
@@ -85,7 +85,7 @@ class MainActivity : AppCompatActivity() {
                 Log.d("BUTTONS", "User tapped the Leave button")
                 call.leave {
                     if (it.isError) {
-                        Log.e(TAG, "Got error while leaving call: ${it.error}")
+                        Log.e(TAG, "Got error while leaving call: ${it.error?.msg}")
                     } else {
                         Log.d(TAG, "Successfully left all")
                     }

--- a/app/src/main/java/com/example/dailyandroidquickstart_kotlin/MainActivity.kt
+++ b/app/src/main/java/com/example/dailyandroidquickstart_kotlin/MainActivity.kt
@@ -54,16 +54,13 @@ class MainActivity : AppCompatActivity() {
         // Create map of video views
         val videoViews = mutableMapOf<ParticipantId, VideoView>()
 
+        val layout = findViewById<LinearLayout>(R.id.videoLinearLayout)
+
         // Listen for events
         call.addListener(object : CallClientListener {
-
             // Handle a remote participant joining
             override fun onParticipantJoined(participant: Participant) {
-                val layout = findViewById<LinearLayout>(R.id.videoLinearLayout)
-
-
                 val participantView = layoutInflater.inflate(R.layout.participant_view, layout, false)
-
                 val videoView = participantView.findViewById<VideoView>(R.id.participant_video)
                 videoView.track = participant.media?.camera?.track
                 videoViews[participant.id] = videoView
@@ -81,15 +78,17 @@ class MainActivity : AppCompatActivity() {
                 toggleCamera.isChecked = inputSettings.camera.isEnabled
                 toggleMicrophone.isChecked = inputSettings.microphone.isEnabled
             }
-
-
         })
 
         findViewById<Button>(R.id.leave)
             .setOnClickListener {
                 Log.d("BUTTONS", "User tapped the Leave button")
                 call.leave {
-                    Log.d("Call", "Call has been left")
+                    if (it.isError) {
+                        Log.e(TAG, "Got error while leaving call: ${it.error}")
+                    } else {
+                        Log.d(TAG, "Call has been left")
+                    }
                 }
             }
 
@@ -114,11 +113,10 @@ class MainActivity : AppCompatActivity() {
                 toggleMicrophone.isChecked = call.inputs().microphone.isEnabled
             }
         }
-
     }
 
     private fun checkPermissions() {
-        //check permissions have been granted and if not, ask for permissions
+        // Check whether permissions have been granted and if not, ask for permissions
         val appContext: Context = applicationContext
 
         val permissionList: Array<String> = appContext.packageManager.getPackageInfo(
@@ -140,7 +138,5 @@ class MainActivity : AppCompatActivity() {
             // permission is granted, we can initialize
             initializeCallClient()
         }
-
     }
-
 }

--- a/app/src/main/java/com/example/dailyandroidquickstart_kotlin/MainActivity.kt
+++ b/app/src/main/java/com/example/dailyandroidquickstart_kotlin/MainActivity.kt
@@ -84,11 +84,9 @@ class MainActivity : AppCompatActivity() {
             .setOnClickListener {
                 Log.d("BUTTONS", "User tapped the Leave button")
                 call.leave {
-                    if (it.isError) {
-                        Log.e(TAG, "Got error while leaving call: ${it.error?.msg}")
-                    } else {
-                        Log.d(TAG, "Successfully left all")
-                    }
+                    it.error?.apply {
+                        Log.e(TAG, "Got error while leaving call: $msg")
+                    } ?: Log.d(TAG, "Successfully left call")
                 }
             }
 

--- a/app/src/main/java/com/example/dailyandroidquickstart_kotlin/MainActivity.kt
+++ b/app/src/main/java/com/example/dailyandroidquickstart_kotlin/MainActivity.kt
@@ -87,7 +87,7 @@ class MainActivity : AppCompatActivity() {
                     if (it.isError) {
                         Log.e(TAG, "Got error while leaving call: ${it.error}")
                     } else {
-                        Log.d(TAG, "Call has been left")
+                        Log.d(TAG, "Successfully left all")
                     }
                 }
             }


### PR DESCRIPTION
This PR:

* Adds a placeholder README (will be expanded with a link to the Quickstart guide once that is live)
* Logs error on call leave (if any) as suggested in Quickstart guide review
* Retrieves the layout once on call init as opposed to for each participant join as suggested in Quickstart guide review
* Reformats a comment and removes some unneeded blank lines